### PR TITLE
fix: 尝试修复waline前端报错

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,7 @@ waline:
     - mail
   wordLimit: 0 # 字数限制,0为不限制
   pageSize: 10 # 每页评论条数
+  pageview: true # 是否开启浏览量统计
 
 # https://github.com/gitalk/gitalk/blob/master/readme-cn.md
 gitalk:

--- a/layout/_mixin/comment.pug
+++ b/layout/_mixin/comment.pug
@@ -21,6 +21,7 @@ mixin CommentRender()
             script(type="module" data-pjax).
                 import { init } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs';
 
+                var path = document.getElementById("twikoo_visitors").attr("data-path");
                 setTimeout(function () {
                     init({
                         el: '#wcomments',
@@ -32,7 +33,8 @@ mixin CommentRender()
                         requiredMeta: !{requiredMeta},
                         wordLimit: #{hexo.theme.config.waline.wordLimit},
                         pageSize: #{hexo.theme.config.waline.pageSize},
-                        pageview: #{theme.waline.pageview}
+                        pageview: #{theme.waline.pageview},
+                        path: path
                     });
                 }, 1000)
         else if gt

--- a/layout/_mixin/comment.pug
+++ b/layout/_mixin/comment.pug
@@ -21,7 +21,7 @@ mixin CommentRender()
             script(type="module" data-pjax).
                 import { init } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs';
 
-                var path = document.getElementById("twikoo_visitors").attr("data-path");
+                var path = document.getElementById("twikoo_visitors").getAttribute("data-path");
                 setTimeout(function () {
                     init({
                         el: '#wcomments',

--- a/layout/_mixin/comment.pug
+++ b/layout/_mixin/comment.pug
@@ -14,6 +14,10 @@ mixin CommentRender()
                 }, 1000)
         else if wl
             div(class="warp" id="wcomments")
+            - var locale = JSON.stringify(theme.waline.locale)
+            - var emoji = JSON.stringify(theme.waline.emoji)
+            - var meta = JSON.stringify(theme.waline.meta)
+            - var requiredMeta = JSON.stringify(theme.waline.requiredMeta)
             script(type="module" data-pjax).
                 import { init } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs';
 
@@ -22,12 +26,13 @@ mixin CommentRender()
                         el: '#wcomments',
                         serverURL: '#{hexo.theme.config.waline.serverURL}',
                         lang: '#{hexo.theme.config.waline.lang}',
-                        locale: #{hexo.theme.config.waline.locale},
-                        emoji: #{hexo.theme.config.waline.emoji},
-                        meta: #{hexo.theme.config.waline.meta},
-                        requiredMeta: #{hexo.theme.config.waline.requiredMeta},
+                        locale: !{locale},
+                        emoji: !{emoji},
+                        meta: !{meta},
+                        requiredMeta: !{requiredMeta},
                         wordLimit: #{hexo.theme.config.waline.wordLimit},
-                        pageSize: #{hexo.theme.config.waline.pageSize}
+                        pageSize: #{hexo.theme.config.waline.pageSize},
+                        pageview: #{theme.waline.pageview}
                     });
                 }, 1000)
         else if gt

--- a/scripts/helpers/asset.js
+++ b/scripts/helpers/asset.js
@@ -38,7 +38,7 @@ hexo.extend.helper.register('_new_comments', function (mode) {
         </script>`
   } else if (mode === 'waline') {
     return `
-    <script type="module">
+    <script type="module" data-pjax>
         import { RecentComments } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs'
         RecentComments({
           el: '#new-comment',

--- a/source/js/_app/page.js
+++ b/source/js/_app/page.js
@@ -567,7 +567,7 @@ const siteRefresh = function (reload) {
     vendorJs('copy_tex');
     vendorCss('mermaid');
     vendorJs('chart');
-    if (!reload) {
+    if (reload !== 1) {
         $dom.each('script[data-pjax]', pjaxScript);
     }
     originTitle = document.title;
@@ -612,7 +612,7 @@ const siteInit = function () {
     window.addEventListener('scroll', scrollHandle);
     window.addEventListener('resize', resizeHandle);
     window.addEventListener('pjax:send', pjaxReload);
-    window.addEventListener('pjax:success', siteRefresh);
+    window.addEventListener('pjax:success', siteRefresh); // 默认会传入一个event参数
     window.addEventListener('beforeunload', function () {
         pagePosition();
     });


### PR DESCRIPTION
实际上waline这样修复只能能跑起来了，但还是有很多bug:
- pjax（大概）导致从首页进入文章（非打开一个新页面)必须刷新一次才能加载出waline（但如果是打开了一个新页面，即target=_blank则不会有这样的问题
- waline的文章统计存放在leancloud中的url默认是以“/”开头的（window.location.pathname），但data-path的值post.path是不带“/”的，这导致前端一直显示为0，但后端还是会正常增加访客数据

以上为在localhost中的测试

PS:waline太tm难用了，还是valine好用（）
我看vendor中好像有minivaline的依赖，但好像没有相关配置？