### PR TITLE
docs: Use "pnpm add" instead of "pnpm install"

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,7 +19,7 @@ SXC install shokaX
 
 ```shell [pnpm]
 # hexo init
-pnpm install shokax-cli --location=global
+pnpm add shokax-cli --location=global
 # cd your_blog
 SXC install shokaX
 ```
@@ -63,11 +63,11 @@ yarn add hexo-feed
 ::: code-group-item pnpm
 
 ```shell [pnpm]
-pnpm i hexo-theme-shokax
-pnpm i hexo-renderer-multi-next-markdown-it
-pnpm i hexo-autoprefixer
-pnpm i hexo-algoliasearch
-pnpm i hexo-feed
+pnpm add hexo-theme-shokax
+pnpm add hexo-renderer-multi-next-markdown-it
+pnpm add hexo-autoprefixer
+pnpm add hexo-algoliasearch
+pnpm add hexo-feed
 ```
 
 :::


### PR DESCRIPTION
根据 [PNPM 文档](https://pnpm.io/cli/add)，`pnpm install` 是安装所有依赖项，`pnpm add` 是安装新包

虽然 `pnpm install` 带参数时和 `pnpm add` 行为相同，也能安装新包（可能是为了兼容？）
但还是用标准语法替换一下吧。。。
